### PR TITLE
chore: change go directive to 1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/urfave/cli v1.22.1
 )
 
-go 1.13
+go 1.11


### PR DESCRIPTION
You package support Go 1.11.

```console
$ docker run -it -v (pwd)/:/anonuuid/ golang:1.11-buster bash
root@c3bdcf7d33ac:/go# cd /anonuuid/
root@c3bdcf7d33ac:/anonuuid# go version
go version go1.11.13 linux/amd64
root@c3bdcf7d33ac:/anonuuid# go build ./cmd/anonuuid/
go: finding github.com/smartystreets/assertions v1.0.1
go: finding github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f
go: finding github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
go: finding github.com/urfave/cli v1.22.1
go: finding github.com/cpuguy83/go-md2man/v2 v2.0.0
go: finding github.com/shurcooL/sanitized_anchor_name v1.0.0
go: finding github.com/pmezard/go-difflib v1.0.0
go: finding github.com/russross/blackfriday/v2 v2.0.1
go: finding github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
go: finding github.com/BurntSushi/toml v0.3.1
go: finding gopkg.in/yaml.v2 v2.2.2
go: finding github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
go: finding github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
go: finding github.com/jtolds/gls v4.20.0+incompatible
go: finding golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
go: finding golang.org/x/net v0.0.0-20190311183353-d8887717615a
go: finding gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: finding golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
go: finding golang.org/x/text v0.3.0
go: finding golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
go: downloading github.com/urfave/cli v1.22.1
go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.0
go: downloading github.com/russross/blackfriday/v2 v2.0.1
go: downloading github.com/shurcooL/sanitized_anchor_name v1.0.0
root@c3bdcf7d33ac:/anonuuid# ./anonuuid -h
NAME:
   anonuuid - Anonymize UUIDs outputs

USAGE:
   anonuuid [global options] command [command options] [arguments...]

VERSION:
   1.0.0-dev

AUTHOR:
   Manfred Touron <https://moul.io/anonuuid>

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --hexspeak                Generate hexspeak style fake UUIDs
   --random, -r              Generate random fake UUIDs
   --keep-beginning          Keep first part of the UUID unchanged
   --keep-end                Keep last part of the UUID unchanged
   --prefix value, -p value  Prefix generated UUIDs
   --suffix value            Suffix generated UUIDs
   --help, -h                show help
   --version, -v             print the version
```